### PR TITLE
Add Lua script to return the 302 status code on 429 status code based on the request path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# istio_test
+
+## How to get the list of virtual_hosts
+
+```
+kubectl exec -it httpbin-0 -c istio-proxy -- curl http://localhost:15000/config_dump|grep -A 10 virtual_hosts
+```

--- a/httpbin-ratelimit-simple.yaml
+++ b/httpbin-ratelimit-simple.yaml
@@ -72,8 +72,12 @@ spec:
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
             inlineCode: |
+              function envoy_on_request(request_handle)
+                request_handle:logWarn("request")
+              end
+
               function envoy_on_response(response_handle)
-                response_handle:logWarn("12345")
+                response_handle:logWarn("response")
                 if response_handle:headers():get(":status") == "429" then
                   response_handle:headers():replace(":status", "302")
                 end

--- a/httpbin-ratelimit-simple.yaml
+++ b/httpbin-ratelimit-simple.yaml
@@ -66,7 +66,7 @@ spec:
               subFilter:
                 name: "envoy.filters.http.router"
       patch:
-        operation: INSERT_BEFORE
+        operation: INSERT_FIRST
         value:
           name: envoy.filters.http.lua
           typed_config:
@@ -74,12 +74,23 @@ spec:
             inlineCode: |
               function envoy_on_request(request_handle)
                 request_handle:logWarn("request")
+                local path = request_handle:headers():get(":path")
+                request_handle:logWarn("path:" .. path )
+                if string.find(path, "^/get/") then 
+                  request_handle:streamInfo():dynamicMetadata():set("path_info", "api", 1)
+                else
+                  request_handle:streamInfo():dynamicMetadata():set("path_info", "api", 0)
+                end
               end
 
               function envoy_on_response(response_handle)
                 response_handle:logWarn("response")
-                if response_handle:headers():get(":status") == "429" then
-                  response_handle:headers():replace(":status", "302")
+                local isApi = response_handle:streamInfo():dynamicMetadata():get("path_info")["api"]
+                response_handle:logWarn("isApi:" .. isApi)
+                if isApi == 0 then
+                  if response_handle:headers():get(":status") == "429" then
+                    response_handle:headers():replace(":status", "302")
+                  end
                 end
               end
     - applyTo: HTTP_ROUTE

--- a/httpbin-ratelimit-simple.yaml
+++ b/httpbin-ratelimit-simple.yaml
@@ -54,7 +54,7 @@ spec:
                     value: "api"
                   token_bucket:
                     max_tokens: 1
-                    tokens_per_file: 1
+                    tokens_per_fill: 1
                     fill_interval: 10s
     - applyTo: HTTP_FILTER
       match:

--- a/httpbin-ratelimit-simple.yaml
+++ b/httpbin-ratelimit-simple.yaml
@@ -73,7 +73,7 @@ spec:
             "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
             inlineCode: |
               function envoy_on_response(response_handle)
-                response_handle:logInfo("12345")
+                response_handle:logWarn("12345")
                 if response_handle:headers():get(":status") == "429" then
                   response_handle:headers():replace(":status", "302")
                 end


### PR DESCRIPTION
- Implemented an Envoy Lua script to handle HTTP responses.
- The script changes status code 429 to 302 and adds a Location header for paths not starting with /get/.
- Configured EnvoyFilter to apply the Lua script conditionally based on the URL prefix.